### PR TITLE
[CLOUD-2008] missing description label

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -1,5 +1,6 @@
 name: "jboss-datagrid-7/datagrid71-client-openshift"
 version: "1.1"
+description: "Red Hat JBoss Data Grid 7.1 client OpenShift container image"
 from: "jboss/base-rhel7:1.0"
 envs:
     - name: "JBOSS_PRODUCT"


### PR DESCRIPTION
the missing description label means that we are inheriting misleading
description and summary labels from base images.

https://issues.jboss.org/browse/CLOUD-2008